### PR TITLE
Added delay before start

### DIFF
--- a/src/BlockEmitter.ts
+++ b/src/BlockEmitter.ts
@@ -16,6 +16,8 @@ import {
 
 import { EventEmitter } from "node:events";
 
+import { timeout } from "./utils.js";
+
 export class TypedEventEmitter<TEvents extends Record<string, any>> {
   private emitter = new EventEmitter();
 
@@ -72,7 +74,12 @@ export class BlockEmitter extends TypedEventEmitter<LocalEventTypes> {
     this.registry = registry;
     this.options = options;
   }
-  public async start() {
+
+  public async start(delaySeconds?: number | string) {
+    if (delaySeconds) {
+      await timeout(Number(delaySeconds) * 1000);
+    }
+
     const track = createStateTracker(this.request);
     const client = createPromiseClient(Stream, this.transport);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export function timeout(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a `delaySeconds` parameter to the `start` method of `BlockEmitter` class, allowing to delay the start of the emitter. It also introduces a `timeout` utility function in `utils.ts`.

### Detailed summary
- Adds `delaySeconds` parameter to `start` method of `BlockEmitter` class
- Introduces `timeout` utility function in `utils.ts` to delay execution of promises

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->