### PR TITLE
Implement CallbackClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,7 @@ emitter.on("fatalError", (error) => {
 console.log("✅ start");
 console.time("🆗 close");
 const cancel = emitter.start();
-// cancel() to exit substreams session
+
+// Cancel after 3 seconds
+setTimeout(cancel, 3000);
 ```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ emitter.on("close", (error) => {
   console.timeEnd("🆗 close");
 });
 
+// Fatal Error
+emitter.on("fatalError", (error) => {
+  console.error(error);
+});
+
 console.log("✅ start");
 console.time("🆗 close");
 const cancel = emitter.start();

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ import { BlockEmitter, createNodeTransport } from "@substreams/node";
 
 // auth API token
 // https://app.streamingfast.io/
+// https://app.pinax.network/
 if (!process.env.SUBSTREAMS_API_TOKEN) {
   throw new Error("SUBSTREAMS_API_TOKEN is require");
 }
 
 const token = process.env.SUBSTREAMS_API_TOKEN;
-const baseUrl = "https://mainnet.eth.streamingfast.io:443";
+const baseUrl = "https://eth.substreams.pinax.network:443";
 
 // User parameters
 const manifest = "https://github.com/pinax-network/subtivity-substreams/releases/download/v0.2.3/subtivity-ethereum-v0.2.3.spkg";
@@ -54,7 +55,6 @@ const request = createRequest({
   outputModule,
   startBlockNum,
   stopBlockNum,
-  productionMode: true,
 });
 
 // NodeJS Events
@@ -72,6 +72,16 @@ emitter.on("anyMessage", (message, cursor, clock) => {
   console.dir(clock);
 });
 
-await emitter.start();
-console.log("✅ done");
+// End of Stream
+emitter.on("close", (error) => {
+  if (error) {
+    console.error(error);
+  }
+  console.timeEnd("🆗 close");
+});
+
+console.log("✅ start");
+console.time("🆗 close");
+const cancel = emitter.start();
+// cancel() to exit substreams session
 ```

--- a/example.js
+++ b/example.js
@@ -52,12 +52,9 @@ emitter.on("anyMessage", (message, cursor, clock) => {
   console.dir(clock);
 });
 
-// End of Stream
-emitter.on("close", (error) => {
-  if (error) {
-    console.error(error);
-  }
-  console.timeEnd("🆗 close");
+// Fatal Error
+emitter.on("fatalError", (error) => {
+  console.error(error);
 });
 
 console.log("✅ start");

--- a/example.js
+++ b/example.js
@@ -52,6 +52,15 @@ emitter.on("anyMessage", (message, cursor, clock) => {
   console.dir(clock);
 });
 
-console.time("✅ done");
-await emitter.start();
-console.timeEnd("✅ done");
+// End of Stream
+emitter.on("close", (error) => {
+  if (error) {
+    console.error(error);
+  }
+  console.timeEnd("🆗 close");
+});
+
+console.log("✅ start");
+console.time("🆗 close");
+const cancel = emitter.start();
+// cancel() to exit substreams session

--- a/example.js
+++ b/example.js
@@ -52,6 +52,14 @@ emitter.on("anyMessage", (message, cursor, clock) => {
   console.dir(clock);
 });
 
+// End of Stream
+emitter.on("close", (error) => {
+  if (error) {
+    console.error(error);
+  }
+  console.timeEnd("🆗 close");
+});
+
 // Fatal Error
 emitter.on("fatalError", (error) => {
   console.error(error);
@@ -60,4 +68,6 @@ emitter.on("fatalError", (error) => {
 console.log("✅ start");
 console.time("🆗 close");
 const cancel = emitter.start();
-// cancel() to exit substreams session
+
+// Cancel after 3 seconds
+setTimeout(cancel, 3000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@substreams/node",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@substreams/node",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substreams/node",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Substreams for Node.js",
   "license": "MIT",
   "repository": "substreams-js/substreams-node",


### PR DESCRIPTION
## Changes

- Replace `createPromiseClient` with `createCallbackClient`
- Replace `emitter.stop()` function with `CancelFn` from Callback Client

**Example**
```ts
const cancel = emitter.start();

// Cancel after 3 seconds
setTimeout(cancel, 3000);
```

## New event emitters
- close
- fatalError

```ts
type LocalEventTypes = {
  close: [error?: ConnectError];
  fatalError: [error: FatalError];
};
```
**Examples**

```ts
// End of Stream
emitter.on("close", (error) => {
  if (error) {
    console.error(error);
  }
});

// Fatal error
emitter.on("fatalError", (error) => {
  console.error(error);
});
```
